### PR TITLE
Update artifact actions to v4

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -42,7 +42,7 @@ jobs:
         $CONDA/bin/conda-merge ci/environment-$SUFFIX.yml environment.yml > ci/combined-environment-$SUFFIX.yml || exit
         done
     - name: Archive combined environments
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: combined-environments
         path: ci/combined-environment-*.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download combined environments
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: combined-environments
         path: ci
@@ -82,7 +82,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download combined environments
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: combined-environments
         path: ci
@@ -116,7 +116,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download combined environments
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: combined-environments
         path: ci

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -28,7 +28,7 @@ jobs:
         $CONDA/bin/conda-merge ci/environment-$SUFFIX.yml environment.yml > ci/combined-environment-$SUFFIX.yml || exit
         done
     - name: Archive combined environments
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: combined-environments
         path: ci/combined-environment-*.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Download combined environments
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: combined-environments
         path: ci


### PR DESCRIPTION
Update upload-artifact and download-artifact actions to v4 as v3 and older are deprecated and will soon be removed. See https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/