### PR TITLE
Enable syntax highlighting in docs notebooks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
   "pre-commit"
 ]
 docs = [
+  "ipython",
   "furo",
   "nbsphinx",
   "roman-numerals-py>=3.1,<4",
@@ -52,7 +53,6 @@ docs = [
 docs-notebooks = [
   "cdsapi",
   "ipykernel",
-  "ipython",
   "earthkit-plots>=1.0rc0",
   "earthkit-transforms>=1.0rc0"
 ]


### PR DESCRIPTION
### Description

Needs ipython, see https://nbsphinx.readthedocs.io/en/0.6.0/installation.html#Pygments-Lexer-for-Syntax-Highlighting.

Closes #60.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
