### PR TITLE
Update earthkit dependencies to v1 releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ classifiers = [
   "Topic :: Scientific/Engineering"
 ]
 dependencies = [
-  "earthkit-data>=1.0rc0",
-  "earthkit-utils>=1.0rc0",
+  "earthkit-data>=1",
+  "earthkit-utils>=1",
   "flox>=0.11",
   "numpy>=1.22",
   "xarray>=2023.1",
@@ -56,8 +56,8 @@ docs = [
 docs-notebooks = [
   "cdsapi",
   "ipykernel",
-  "earthkit-plots>=1.0rc0",
-  "earthkit-transforms>=1.0rc0"
+  "earthkit-plots>=1",
+  "earthkit-transforms>=1"
 ]
 test = [
   "pytest",


### PR DESCRIPTION
Earthkit 1.0 is out, we don't need to depend on release candidates anymore.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
